### PR TITLE
Added functionality to parse metadata.

### DIFF
--- a/server/src/compile/parser.ts
+++ b/server/src/compile/parser.ts
@@ -150,6 +150,7 @@ function parseScript(parsing: ParsingState): NodeScript {
             continue;
         }
 
+        parseMetadata(parsing);
         const parsedVar = parseVar(parsing);
         if (parsedVar !== undefined) {
             script.push(parsedVar);
@@ -302,6 +303,7 @@ function parseEntityAttribute(parsing: ParsingState): EntityAttribute | undefine
 function parseClass(parsing: ParsingState): TriedParse<NodeClass> {
     const rangeStart = parsing.next();
 
+    parseMetadata(parsing);
     const entity = parseEntityAttribute(parsing);
 
     if (parsing.next().text !== 'class') {
@@ -414,6 +416,7 @@ function parseTypeDef(parsing: ParsingState): TriedParse<NodeTypeDef> {
 function parseFunc(parsing: ParsingState): NodeFunc | undefined {
     const rangeStart = parsing.next();
 
+    parseMetadata(parsing);
     const entityAttribute = parseEntityAttribute(parsing);
 
     const accessor = parseAccessModifier(parsing);
@@ -487,6 +490,15 @@ function parseRef(parsing: ParsingState) {
     const isRef = parsing.next().text === '&';
     if (isRef) parsing.confirm(HighlightToken.Builtin);
     return isRef;
+}
+
+function parseMetadata(parsing: ParsingState) {
+    while (parsing.isEnd() === false) {
+        if (parsing.next().kind != TokenKind.Metadata) {
+            return;
+        }
+        parsing.step();
+    }
 }
 
 // ['private' | 'protected']
@@ -577,6 +589,7 @@ function expectInterfaceMembers(parsing: ParsingState): (NodeIntfMethod | NodeVi
 function parseVar(parsing: ParsingState): NodeVar | undefined {
     const rangeStart = parsing.next();
 
+    parseMetadata(parsing);
     const accessor = parseAccessModifier(parsing);
 
     const type = parseType(parsing);
@@ -717,6 +730,7 @@ function parseFuncDef(parsing: ParsingState): TriedParse<NodeFuncDef> {
 function parseVirtualProp(parsing: ParsingState): NodeVirtualProp | undefined {
     const rangeStart = parsing.next();
 
+    parseMetadata(parsing);
     const accessor = parseAccessModifier(parsing);
 
     const type = parseType(parsing);

--- a/server/src/compile/tokenizer.ts
+++ b/server/src/compile/tokenizer.ts
@@ -8,6 +8,7 @@ import {
     TokenIdentifier,
     TokenizingToken,
     TokenKind,
+    TokenMetadata,
     TokenNumber,
     TokenReserved,
     TokenString
@@ -44,6 +45,39 @@ function tryComment(reading: TokenizingState, location: LocationInfo): TokenComm
         return tokenizeBlockComment(reading, location);
     }
     return undefined;
+}
+
+function tryMetadata(reading: TokenizingState, location: LocationInfo): TokenMetadata | undefined {
+    const start = reading.getCursor();
+    if (reading.next() !== '[') return undefined;
+
+    reading.stepFor(1);
+
+    let level = 1;
+
+    for (; ;) {
+        if (reading.isEnd()) break;
+        if (reading.isNext('[')) {
+            level += 1;
+        }
+        if (reading.isNext(']')) {
+            reading.stepNext();
+            level -= 1;
+            if (level === 0) {
+                break;
+            }
+            continue;
+        }
+        reading.stepNext();
+    }
+
+    location.end = reading.copyHead();
+    return {
+        kind: TokenKind.Metadata,
+        text: reading.substrFrom(start),
+        location: location,
+        highlight: createHighlight(HighlightToken.Decorator, HighlightModifier.Nothing)
+    }
 }
 
 function createTokenComment(comment: string, location: LocationInfo): TokenComment | undefined {
@@ -284,6 +318,12 @@ export function tokenize(str: string, path: string): TokenizingToken[] {
         const triedNumber = tryNumber(reading, location);
         if (triedNumber !== undefined) {
             tokens.push(triedNumber);
+            continue;
+        }
+
+        const triedMetadata = tryMetadata(reading, location);
+        if (triedMetadata !== undefined) {
+            tokens.push(triedMetadata);
             continue;
         }
 

--- a/server/src/compile/tokens.ts
+++ b/server/src/compile/tokens.ts
@@ -6,6 +6,7 @@ export enum TokenKind {
     Identifier = 'Identifier',
     Number = 'Number',
     String = 'String',
+    Metadata = 'Metadata',
     Comment = 'Comment',
 }
 
@@ -124,4 +125,8 @@ export interface TokenComment extends TokenBase {
     kind: TokenKind.Comment;
 }
 
-export type TokenizingToken = TokenReserved | TokenIdentifier | TokenNumber | TokenString | TokenComment;
+export interface TokenMetadata extends TokenBase {
+    kind: TokenKind.Metadata;
+}
+
+export type TokenizingToken = TokenReserved | TokenIdentifier | TokenNumber | TokenString | TokenComment | TokenMetadata;


### PR DESCRIPTION
Hello! First off, thank you so much for this amazing project.

#### Rationale
I noticed that the lsp lacked support for metadata, as defined [here](https://angelcode.com/angelscript/sdk/docs/manual/doc_addon_build.html#doc_addon_build_metadata). I was originally going to make an issue for this but i thought why not give it a try.

Even though, the builder addon is not core AngelScript, metadata are harmless enough that it would be cool to have them supported out of the box.

Let me know if you don't like anything but please feel free to close this PR if you don't want this feature/don't like my implementation.

#### Implementation

Metadata are anything defined between `[` and `]` and attached to classes, variables, properties, methods and functions. They are essentially strings so i treat them as such in the code. However, to disallow using actual strings in place of metadata and vice-versa, i declared a new token type, `Metadata`.

The angelscript builder addon, allows multiple metadata declarations in the same place and the only other rule is the matching count of `[` and `]`, eg. `[Hello[]]` is ok but `[Hello[]` is not.

Here is an example script with metadata:
```angelscript
[Generator = ClassFactory]
class MyClass {
    [NetworkReplicate[Interval = 1]]
    [Serializable]
    int MyVar;

    [HereToo]
    bool MyProp {
        get const {
            return false;
        }
    }

    [NetworkInvokeable]
    void Method() {

    }
}

[Event]
bool FreeFloatingFunc() {

}

[Factory for MyClass]
MyClass ClassFactory() {
}
```

Also, for feature issues/features are you ok with me creating new issues or PRs when i can?