### PR TITLE
[new] Added hoistEnumParentScope setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,12 @@
                     "default": false,
                     "description": "Project files implicitly include each other (like C# or Java)"
                 },
+                "angelScript.hoistEnumParentScope": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Hoist enums to their parents scope."
+                },
                 "angelScript.formatter.maxBlankLines": {
                     "scope": "window",
                     "type": "number",

--- a/server/src/code/settings.ts
+++ b/server/src/code/settings.ts
@@ -4,6 +4,7 @@
  */
 export interface LanguageServerSettings {
     implicitMutualInclusion: boolean;
+    hoistEnumParentScope: boolean;
     builtinStringTypes: string[];
     builtinArrayType: string,
     formatter: {
@@ -18,6 +19,7 @@ export interface LanguageServerSettings {
 
 const defaultSettings: LanguageServerSettings = {
     implicitMutualInclusion: false,
+    hoistEnumParentScope: false,
     builtinStringTypes: ["string", "String"],
     builtinArrayType: "array",
     formatter: {

--- a/server/src/compile/analyzer.ts
+++ b/server/src/compile/analyzer.ts
@@ -166,6 +166,9 @@ function hoistEnum(parentScope: SymbolScope, nodeEnum: NodeEnum) {
     symbol.membersScope = scope;
 
     hoistEnumMembers(scope, nodeEnum.memberList, {symbolType: symbol, sourceScope: scope});
+
+    if (getGlobalSettings().hoistEnumParentScope)
+        hoistEnumMembers(parentScope, nodeEnum.memberList, {symbolType: symbol, sourceScope: scope});
 }
 
 function hoistEnumMembers(parentScope: SymbolScope, memberList: ParsedEnumMember[], type: DeducedType) {


### PR DESCRIPTION
Allows users to use enums in their parents scope. Disabled by default. 

# Example:

```
namespace GameState {
  enum State {
    game,
    menu,
  }
}
```

Before you could access the enum by doing `GameState::State::game`, now you can do `GameState::game`, which is allowed by AngelScript.




