### PR TITLE
[fix] Allow funcdefs to be passed into ?

### DIFF
--- a/server/src/compile/checkType.ts
+++ b/server/src/compile/checkType.ts
@@ -66,6 +66,11 @@ function isTypeMatchInternal(
 
     // Check the function handler type.
     if (srcType.symbolKind === SymbolKind.Function) {
+
+        // Are we trying to pass something into ?
+        if (destType.symbolKind === SymbolKind.Type)
+            if (destType.sourceType === PrimitiveType.Any) return true;
+
         // if (dest.isHandler === false) return false; // FIXME: Handler Checking?
         return isFunctionHandlerMatch(srcType, destType);
     } else if (destType.symbolKind === SymbolKind.Function) {


### PR DESCRIPTION
Prior to this, you could not pass funcdef into a function that has '?/any'

Minimal example:

Angelscript:
```
funcdef void foo();

void test()
{
    func(@foo);
}
```

as.predefined
```
void func(?&in);
```

Before this PR, it would error out. If there is a better way to patch/add this in, just let me know :)