### PR TITLE
[fix] Allow enum values to be assigned to numbers

### DIFF
--- a/server/src/compile/checkType.ts
+++ b/server/src/compile/checkType.ts
@@ -84,6 +84,8 @@ function isTypeMatchInternal(
         // OK if they both point to the same type.
         if (srcType.declaredPlace === destType.declaredPlace) return true;
 
+        if (srcNode.nodeName === NodeName.Enum && destNode === PrimitiveType.Number) return true;
+
         // OK if any of the inherited types in the source match the destination.
         if (canDownCast(srcType, destType)) return true;
     }


### PR DESCRIPTION
This pr allows enums to get assigned/passed to numbers

Minimal example:
```
enum Hello {
    hi = 0
}

void test()
{
    uint8 test = Hello::hi;
}
```

Before this PR, it would not be able to convert enum into uint8.