### PR TITLE
Add 'not' as an alternative to '!'

### DIFF
--- a/server/src/compile/tokenReservedWords.ts
+++ b/server/src/compile/tokenReservedWords.ts
@@ -28,7 +28,7 @@ const reservedKeywordArray = [
     // 'abstract', 'explicit', 'external', 'function', 'final', 'from', 'get', 'set', 'shared', 'super', 'this',
 ];
 
-const exprPreOpSet = new Set(['-', '+', '!', '++', '--', '~', '@']);
+const exprPreOpSet = new Set(['-', '+', '!', '++', '--', '~', '@', 'not']);
 
 const bitOpSet = new Set(['&', '|', '^', '<<', '>>', '>>>']);
 

--- a/server/test/compile/parser.spec.ts
+++ b/server/test/compile/parser.spec.ts
@@ -79,4 +79,5 @@ describe("Parser", () => {
             bool w = v == Test::A;
         }
     `);
+    itParses(`bool foo = not true; bool bar = not not false;`)
 });


### PR DESCRIPTION
https://www.angelcode.com/angelscript/sdk/docs/manual/doc_expressions.html#logic

`exprPreOpSet` Seems to be the correct place for this, but if not, let me know!

The following code should now work
```
bool foo = not false;
bool bar = !not true;
bool baz = not not true;

if (not foo == not bar or not baz) {} 
```