### PR TITLE
Fix a crash when inspecting nested directories

### DIFF
--- a/server/src/services/inspector.ts
+++ b/server/src/services/inspector.ts
@@ -140,7 +140,7 @@ function inspectAllFilesUnderDirectory(dirUri: string) {
     for (const entry of entries) {
         const fileUri = resolveUri(dirUri, entry.name);
         if (entry.isDirectory()) {
-            inspectAllFilesUnderDirectory(fileUri);
+            inspectAllFilesUnderDirectory(`${fileUri}/`);
         } else if (entry.isFile() && fileUri.endsWith('.as')) {
             const content = readFileFromUri(fileUri);
             if (content !== undefined) inspectFile(content, fileUri);


### PR DESCRIPTION
Before this fix, if you had a nested directory structure like:

```
src/
+- as.predefined
+- foo/
|  +- bar/
```

After finding the predefined file, `inspectAllFilesUnderDirectory` will be called on the directory `"src/"`. Then `entry.name = "foo"` is found, meaning `fileUri = "src/foo"` without a trailing slash! This means that the next step will calculate `resolveUri("src/foo", "bar") == "src/bar"` which results in `Error: ENOENT: no such file or directory`.