### PR TITLE
basic support for `foreach` and typed enums

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,18 @@
                     "default": true,
                     "description": "Controls whether the 'property' keyword is required for virtual property accessors. When set to true, functions must explicitly use the 'property' keyword to be treated as property accessors. When false, compatibility mode for AngelScript prior to v2.33.1 is enabled, and functions with 'get_' or 'set_' prefixes are automatically treated as property accessors."
                 },
+                "angelScript.supportsTypedEnumerations": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether your codebase supports typed enumerations."
+                },
+                "angelScript.supportsForEach": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether your codebase supports the foreach construct."
+                },
                 "angelScript.formatter.maxBlankLines": {
                     "scope": "window",
                     "type": "number",

--- a/server/src/compiler_analyzer/analyzer.ts
+++ b/server/src/compiler_analyzer/analyzer.ts
@@ -133,16 +133,16 @@ export function analyzeVar(scope: SymbolScope, nodeVar: NodeVar, isInstanceMembe
 
 // TYPE IDENTIFIER
 export function analyzeForEachVar(scope: SymbolScope, nodeForEachVar: NodeForEachVar, nodeAssign: NodeAssign) {
-	// TODO: figure out how to resolve `opForValue{N}`
-	// when `auto` is used
-	const variable: SymbolVariable = SymbolVariable.create({
-		defToken: nodeForEachVar.identifier,
-		defScope: scope.scopePath,
-		type: analyzeType(scope, nodeForEachVar.type),
-		isInstanceMember: false,
-		accessRestriction: undefined,
-	});
-	scope.insertSymbolAndCheck(variable);
+    // TODO: figure out how to resolve `opForValue{N}`
+    // when `auto` is used
+    const variable: SymbolVariable = SymbolVariable.create({
+        defToken: nodeForEachVar.identifier,
+        defScope: scope.scopePath,
+        type: analyzeType(scope, nodeForEachVar.type),
+        isInstanceMember: false,
+        accessRestriction: undefined,
+    });
+    scope.insertSymbolAndCheck(variable);
 }
 
 export function insertVariables(scope: SymbolScope, varType: ResolvedType | undefined, nodeVar: NodeVar, isInstanceMember: boolean) {
@@ -453,12 +453,12 @@ function analyzeFor(scope: SymbolScope, nodeFor: NodeFor) {
 
 // FOREACH       ::= 'foreach' '(' TYPE IDENTIFIER {',' TYPE INDENTIFIER} ':' ASSIGN ')' STATEMENT
 function analyzeForEach(scope: SymbolScope, nodeForEach: NodeForEach) {
-	// analyze assign first, since vars may need it
+    // analyze assign first, since vars may need it
     analyzeAssign(scope, nodeForEach.assign as NodeAssign);
 
-	for (const v of nodeForEach.variables) {
-		analyzeForEachVar(scope, v, nodeForEach.assign as NodeAssign);
-	}
+    for (const v of nodeForEach.variables) {
+        analyzeForEachVar(scope, v, nodeForEach.assign as NodeAssign);
+    }
 
     if (nodeForEach.statement !== undefined) analyzeStatement(scope, nodeForEach.statement);
 }

--- a/server/src/compiler_analyzer/symbolScope.ts
+++ b/server/src/compiler_analyzer/symbolScope.ts
@@ -64,7 +64,7 @@ export type ScopeLinkedNode =
     // Statement nodes
     | NodeStatBlock
     | NodeFor
-	| NodeForEach
+    | NodeForEach
     | NodeWhile
     | NodeDoWhile
     | NodeIf

--- a/server/src/compiler_analyzer/symbolScope.ts
+++ b/server/src/compiler_analyzer/symbolScope.ts
@@ -11,6 +11,7 @@ import {
     NodeDoWhile,
     NodeEnum,
     NodeFor,
+    NodeForEach,
     NodeFunc,
     NodeIf,
     NodeInterface,
@@ -63,6 +64,7 @@ export type ScopeLinkedNode =
     // Statement nodes
     | NodeStatBlock
     | NodeFor
+	| NodeForEach
     | NodeWhile
     | NodeDoWhile
     | NodeIf

--- a/server/src/compiler_parser/nodes.ts
+++ b/server/src/compiler_parser/nodes.ts
@@ -131,7 +131,7 @@ export interface NodeEnum extends NodesBase {
     readonly entity: EntityAttribute | undefined;
     readonly identifier: TokenObject;
     readonly memberList: ParsedEnumMember[];
-	readonly enumType: TokenReserved;
+    readonly enumType: TokenReserved;
 }
 
 export interface ParsedEnumMember {
@@ -321,7 +321,7 @@ export interface NodeDataType extends NodesBase {
 export type NodeStatement =
     NodeIf
     | NodeFor
-	| NodeForEach
+    | NodeForEach
     | NodeWhile
     | NodeReturn
     | NodeStatBlock

--- a/server/src/compiler_parser/nodes.ts
+++ b/server/src/compiler_parser/nodes.ts
@@ -1,4 +1,4 @@
-import {TokenObject} from "../compiler_tokenizer/tokenObject";
+import {TokenObject, TokenReserved} from "../compiler_tokenizer/tokenObject";
 import {TokenRange} from "./tokenRange";
 
 export enum AccessModifier {
@@ -58,6 +58,8 @@ export enum NodeName {
     Switch = 'Switch',
     Break = 'Break',
     For = 'For',
+    ForEach = 'ForEach',
+    ForEachVar = 'ForEachVar',
     While = 'While',
     DoWhile = 'DoWhile',
     If = 'If',
@@ -129,6 +131,7 @@ export interface NodeEnum extends NodesBase {
     readonly entity: EntityAttribute | undefined;
     readonly identifier: TokenObject;
     readonly memberList: ParsedEnumMember[];
+	readonly enumType: TokenReserved;
 }
 
 export interface ParsedEnumMember {
@@ -314,10 +317,11 @@ export interface NodeDataType extends NodesBase {
 
 // FUNCATTR      ::= {'override' | 'final' | 'explicit' | 'property'}
 
-// STATEMENT     ::= (IF | FOR | WHILE | RETURN | STATBLOCK | BREAK | CONTINUE | DOWHILE | SWITCH | EXPRSTAT | TRY)
+// STATEMENT     ::= (IF | FOR | FOREACH | WHILE | RETURN | STATBLOCK | BREAK | CONTINUE | DOWHILE | SWITCH | EXPRSTAT | TRY)
 export type NodeStatement =
     NodeIf
     | NodeFor
+	| NodeForEach
     | NodeWhile
     | NodeReturn
     | NodeStatBlock
@@ -346,6 +350,21 @@ export interface NodeFor extends NodesBase {
     readonly initial: NodeVar | NodeExprStat,
     readonly condition: NodeExprStat | undefined
     readonly incrementList: NodeAssign[],
+    readonly statement: NodeStatement | undefined
+}
+
+// like NodeVar but no initializer or modifier
+export interface NodeForEachVar extends NodesBase {
+    readonly nodeName: NodeName.ForEachVar
+    readonly type: NodeType,
+    readonly identifier: TokenObject;
+}
+
+// FOREACH       ::= 'foreach' '(' TYPE IDENTIFIER {',' TYPE INDENTIFIER} ':' ASSIGN ')' STATEMENT
+export interface NodeForEach extends NodesBase {
+    readonly nodeName: NodeName.ForEach
+    readonly variables: NodeForEachVar[],
+    readonly assign: NodeAssign | undefined,
     readonly statement: NodeStatement | undefined
 }
 

--- a/server/src/compiler_parser/parser.ts
+++ b/server/src/compiler_parser/parser.ts
@@ -239,18 +239,18 @@ function parseEnum(parser: ParserState): ParseResult<NodeEnum> {
     const identifier = expectIdentifier(parser, HighlightForToken.Enum);
     if (identifier === undefined) return ParseFailure.Pending;
 
-	let enumType = TokenReserved.createVirtual('int32');
-	if (getGlobalSettings().supportsTypedEnumerations && parser.next().text === ':') {
+    let enumType = TokenReserved.createVirtual('int32');
+    if (getGlobalSettings().supportsTypedEnumerations && parser.next().text === ':') {
         parser.commit(HighlightForToken.Operator);
-		const typeIdentifier = parsePrimeType(parser);
+        const typeIdentifier = parsePrimeType(parser);
 
-		if (typeIdentifier === undefined) {
-			parser.backtrack(rangeStart);
-			return ParseFailure.Mismatch;
-		}
+        if (typeIdentifier === undefined) {
+            parser.backtrack(rangeStart);
+            return ParseFailure.Mismatch;
+        }
 
-		enumType = typeIdentifier;
-	}
+        enumType = typeIdentifier;
+    }
 
     let memberList: ParsedEnumMember[] = [];
     const scopeStart = parser.next();
@@ -268,7 +268,7 @@ function parseEnum(parser: ParserState): ParseResult<NodeEnum> {
         entity: entity,
         identifier: identifier,
         memberList: memberList,
-		enumType: enumType
+        enumType: enumType
     };
 }
 
@@ -428,23 +428,23 @@ function expectClassMembers(parser: ParserState) {
 
 // TYPE IDENTIFIER
 function parseForEachVar(parser: ParserState): NodeForEachVar | undefined {
-	const rangeStart = parser.next();
+    const rangeStart = parser.next();
     const type = expectType(parser);
 
-	if (type === undefined)
-		return undefined;
+    if (type === undefined)
+        return undefined;
 
     const identifier = expectIdentifier(parser, HighlightForToken.Variable);
 
-	if (identifier === undefined)
-		return undefined;
+    if (identifier === undefined)
+        return undefined;
 
-	return {
-		nodeName: NodeName.ForEachVar,
-		nodeRange: new TokenRange(rangeStart, parser.prev()),
-		type: type,
-		identifier: identifier
-	};
+    return {
+        nodeName: NodeName.ForEachVar,
+        nodeRange: new TokenRange(rangeStart, parser.prev()),
+        type: type,
+        identifier: identifier
+    };
 }
 
 // TYPEDEF       ::= 'typedef' PRIMTYPE IDENTIFIER ';'
@@ -1351,12 +1351,12 @@ function parseStatement(parser: ParserState): ParseResult<NodeStatement> {
     if (parsedFor === ParseFailure.Pending) return ParseFailure.Pending;
     if (parsedFor !== ParseFailure.Mismatch) return parsedFor;
 
-	if (getGlobalSettings().supportsForEach)
-	{
-		const parsedForEach = parseForEach(parser);
-		if (parsedForEach === ParseFailure.Pending) return ParseFailure.Pending;
-		if (parsedForEach !== ParseFailure.Mismatch) return parsedForEach;
-	}
+    if (getGlobalSettings().supportsForEach)
+    {
+        const parsedForEach = parseForEach(parser);
+        if (parsedForEach === ParseFailure.Pending) return ParseFailure.Pending;
+        if (parsedForEach !== ParseFailure.Mismatch) return parsedForEach;
+    }
 
     const parsedWhile = parseWhile(parser);
     if (parsedWhile === ParseFailure.Pending) return ParseFailure.Pending;
@@ -1503,28 +1503,28 @@ function parseForEach(parser: ParserState): ParseResult<NodeForEach> {
         nodeRange: new TokenRange(rangeStart, parser.prev()),
         variables: [],
         statement: undefined,
-		assign: undefined
+        assign: undefined
     };
 
     while (parser.isEnd() === false) {
         if (expectSeparatorOrClose(parser, ',', ':', result.variables.length > 0) === BreakOrThrough.Break) break;
 
-		const variable = parseForEachVar(parser);
+        const variable = parseForEachVar(parser);
 
-		if (variable === undefined) {
-			parser.error("Invalid variable declaration.");
-			return ParseFailure.Pending;
-		}
+        if (variable === undefined) {
+            parser.error("Invalid variable declaration.");
+            return ParseFailure.Pending;
+        }
 
-		result.variables.push(variable);
-	}
+        result.variables.push(variable);
+    }
 
     result.assign = expectAssign(parser);
 
     if (parser.expect(')', HighlightForToken.Operator) === false) return appliedNodeEnd(parser, result);
 
     result.statement = expectStatement(parser);
-	
+    
     return appliedNodeEnd(parser, result);
 }
 

--- a/server/src/compiler_parser/parser.ts
+++ b/server/src/compiler_parser/parser.ts
@@ -1507,15 +1507,7 @@ function parseForEach(parser: ParserState): ParseResult<NodeForEach> {
     };
 
     while (parser.isEnd() === false) {
-		if (parser.next().text === ':') {
-			if (!result.variables.length) {
-				parser.error("Expected at least one variable declaration.");
-				return ParseFailure.Pending;				
-			}
-
-			parser.expect(':', HighlightForToken.Operator);
-			break;
-		}
+        if (expectSeparatorOrClose(parser, ',', ':', result.variables.length > 0) === BreakOrThrough.Break) break;
 
 		const variable = parseForEachVar(parser);
 

--- a/server/src/core/settings.ts
+++ b/server/src/core/settings.ts
@@ -7,8 +7,8 @@ export interface LanguageServerSettings {
     implicitMutualInclusion: boolean;
     hoistEnumParentScope: boolean;
     explicitPropertyAccessor: boolean;
-	supportsForEach: boolean;
-	supportsTypedEnumerations: boolean;
+    supportsForEach: boolean;
+    supportsTypedEnumerations: boolean;
     builtinStringTypes: string[];
     builtinArrayType: string,
     formatter: {
@@ -26,8 +26,8 @@ const defaultSettings: LanguageServerSettings = {
     implicitMutualInclusion: false,
     hoistEnumParentScope: false,
     explicitPropertyAccessor: false,
-	supportsForEach: false,
-	supportsTypedEnumerations: false,
+    supportsForEach: false,
+    supportsTypedEnumerations: false,
     builtinStringTypes: ["string", "String"],
     builtinArrayType: "array",
     formatter: {

--- a/server/src/core/settings.ts
+++ b/server/src/core/settings.ts
@@ -7,6 +7,8 @@ export interface LanguageServerSettings {
     implicitMutualInclusion: boolean;
     hoistEnumParentScope: boolean;
     explicitPropertyAccessor: boolean;
+	supportsForEach: boolean;
+	supportsTypedEnumerations: boolean;
     builtinStringTypes: string[];
     builtinArrayType: string,
     formatter: {
@@ -24,6 +26,8 @@ const defaultSettings: LanguageServerSettings = {
     implicitMutualInclusion: false,
     hoistEnumParentScope: false,
     explicitPropertyAccessor: false,
+	supportsForEach: false,
+	supportsTypedEnumerations: false,
     builtinStringTypes: ["string", "String"],
     builtinArrayType: "array",
     formatter: {


### PR DESCRIPTION
`foreach` is an upstream feature coming in the next version of Angelscript. This PR adds support for the syntax and typed foreach statements:

```cpp
foreach (int x : a) { }

foreach (string a, int b : c) { }
```

I call this basic support because it doesn't yet support evaluating `auto` types. I need to dig a bit more into how the analyzer works.

This also adds basic support for typed enumerations, a feature I use in my fork of Angelscript that I submitted as a feature patch to the maintainer of Angelscript - I'm hoping to have it land in the next version but it'll be in there eventually either way.

```cpp
enum MyEnum : int16
{
// regular enum values
}
```

This probably doesn't need any more work, although having a diagnostic for overflowing enum value might be useful.