### PR TITLE
Basic support for template functions

### DIFF
--- a/server/src/compiler_analyzer/analyzer.ts
+++ b/server/src/compiler_analyzer/analyzer.ts
@@ -102,6 +102,16 @@ export function analyzeFunc(scope: SymbolScope, func: NodeFunc) {
         return;
     }
 
+    const declared = findSymbolWithParent(scope, func.identifier.text);
+
+    if (declared === undefined) {
+        // TODO: required?
+        analyzerDiagnostic.add(func.identifier.location, `'${func.identifier}' is not defined.`);
+        return;
+    }
+
+    const typeTemplates = analyzeTemplateTypes(scope, func.typeTemplates, (declared.symbol as SymbolFunctionHolder).first.templateTypes);
+
     // Add arguments to the scope
     analyzeParamList(scope, func.paramList);
 

--- a/server/src/compiler_analyzer/hoist.ts
+++ b/server/src/compiler_analyzer/hoist.ts
@@ -313,6 +313,9 @@ function hoistFunc(
     const funcScope: SymbolScope = parentScope.insertScope(nodeFunc.identifier.text, nodeFunc);
     const scope = funcScope.insertScope(createAnonymousIdentifier(), undefined);
 
+    const templateTypes = hoistClassTemplateTypes(scope, nodeFunc.typeTemplates);
+    if (templateTypes.length > 0) symbol.mutate().templateTypes = templateTypes;
+
     hoisting.push(() => {
         symbol.mutate().parameterTypes = hoistParamList(scope, nodeFunc.paramList);
     });

--- a/server/src/compiler_analyzer/symbolObject.ts
+++ b/server/src/compiler_analyzer/symbolObject.ts
@@ -215,6 +215,8 @@ export class SymbolFunction extends SymbolBase {
         public readonly parameterTypes: (ResolvedType | undefined)[],
         public readonly isInstanceMember: boolean,
         public readonly accessRestriction: AccessModifier | undefined,
+        // Template type parameters (i.e., 'class A<T, U>' has two template types 'T' and 'U')
+        public readonly templateTypes?: TokenObject[],
     ) {
         super();
     }

--- a/server/src/compiler_parser/nodes.ts
+++ b/server/src/compiler_parser/nodes.ts
@@ -172,6 +172,7 @@ export interface NodeFunc extends NodesBase {
     readonly isConst: boolean;
     readonly funcAttr: FunctionAttribute | undefined;
     readonly statBlock: NodeStatBlock;
+    readonly typeTemplates: NodeType[];
 }
 
 export interface FuncHeadReturnValue {
@@ -552,7 +553,8 @@ export interface NodeFuncCall extends NodesBase {
     readonly nodeName: NodeName.FuncCall
     readonly scope: NodeScope | undefined,
     readonly identifier: TokenObject,
-    readonly argList: NodeArgList
+    readonly argList: NodeArgList,
+    readonly typeTemplates: NodeType[] | undefined;
 }
 
 // BNF: VARACCESS     ::= SCOPE IDENTIFIER

--- a/server/src/compiler_parser/parser.ts
+++ b/server/src/compiler_parser/parser.ts
@@ -503,7 +503,7 @@ function parseFunc(parser: ParserState): NodeFunc | undefined {
     const identifier = parser.next();
     parser.commit(isFuncHeadReturnValue(head) ? HighlightForToken.Function : HighlightForToken.Type);
 
-	const typeTemplates = parseTypeTemplates(parser) ?? [];
+    const typeTemplates = parseTypeTemplates(parser) ?? [];
 
     const paramList = parseParamList(parser);
     if (paramList === undefined) {
@@ -541,7 +541,7 @@ function parseFunc(parser: ParserState): NodeFunc | undefined {
         isConst: isConst,
         funcAttr: funcAttr,
         statBlock: statBlock,
-		typeTemplates: typeTemplates
+        typeTemplates: typeTemplates
     };
 }
 
@@ -2199,7 +2199,7 @@ function parseFuncCall(parser: ParserState): NodeFuncCall | undefined {
         return undefined;
     }
 
-	const typeTemplates = parseTypeTemplates(parser) ?? [];
+    const typeTemplates = parseTypeTemplates(parser) ?? [];
 
     const argList = parseArgList(parser);
     if (argList === undefined) {
@@ -2213,7 +2213,7 @@ function parseFuncCall(parser: ParserState): NodeFuncCall | undefined {
         scope: scope,
         identifier: identifier,
         argList: argList,
-		typeTemplates: typeTemplates
+        typeTemplates: typeTemplates
     };
 }
 

--- a/server/src/compiler_parser/parser.ts
+++ b/server/src/compiler_parser/parser.ts
@@ -503,6 +503,8 @@ function parseFunc(parser: ParserState): NodeFunc | undefined {
     const identifier = parser.next();
     parser.commit(isFuncHeadReturnValue(head) ? HighlightForToken.Function : HighlightForToken.Type);
 
+	const typeTemplates = parseTypeTemplates(parser) ?? [];
+
     const paramList = parseParamList(parser);
     if (paramList === undefined) {
         parser.backtrack(rangeStart);
@@ -538,7 +540,8 @@ function parseFunc(parser: ParserState): NodeFunc | undefined {
         paramList: paramList,
         isConst: isConst,
         funcAttr: funcAttr,
-        statBlock: statBlock
+        statBlock: statBlock,
+		typeTemplates: typeTemplates
     };
 }
 
@@ -2196,6 +2199,8 @@ function parseFuncCall(parser: ParserState): NodeFuncCall | undefined {
         return undefined;
     }
 
+	const typeTemplates = parseTypeTemplates(parser) ?? [];
+
     const argList = parseArgList(parser);
     if (argList === undefined) {
         parser.backtrack(rangeStart);
@@ -2207,7 +2212,8 @@ function parseFuncCall(parser: ParserState): NodeFuncCall | undefined {
         nodeRange: new TokenRange(rangeStart, parser.prev()),
         scope: scope,
         identifier: identifier,
-        argList: argList
+        argList: argList,
+		typeTemplates: typeTemplates
     };
 }
 


### PR DESCRIPTION
This is a feature part of the WIP branch of AS. Allows them to be parsed, and very basic analysis support.
Does not yet support analyzing the return value (same issue as the `foreach` impl, I'm not yet sure how to properly implement that on the analysis side). It probably also doesn't play well with overloads, but it's rare to have a templated function have non-templated overloads atm given how basic function templates are.

```
T host_exported_func<T, U, V>(T x, U &y, V @v);
```

It also doesn't throw any errors if the function is not in an as.predefined scope, but it probably should.