### PR TITLE
Support for parsing list factories

### DIFF
--- a/server/bnf.txt
+++ b/server/bnf.txt
@@ -3,7 +3,9 @@ NAMESPACE     ::= 'namespace' IDENTIFIER {'::' IDENTIFIER} '{' SCRIPT '}'
 ENUM          ::= {'shared' | 'external'} 'enum' IDENTIFIER [ ':' ('int' | 'int8' | 'int16' | 'int32' | 'int64' | 'uint' | 'uint8' | 'uint16' | 'uint32' | 'uint64') ] (';' | ('{' IDENTIFIER ['=' EXPR] {',' IDENTIFIER ['=' EXPR]} '}'))
 CLASS         ::= {'shared' | 'abstract' | 'final' | 'external'} 'class' IDENTIFIER (';' | ([':' IDENTIFIER {',' IDENTIFIER}] '{' {VIRTPROP | FUNC | VAR | FUNCDEF} '}'))
 TYPEDEF       ::= 'typedef' PRIMTYPE IDENTIFIER ';'
-FUNC          ::= {'shared' | 'external'} ['private' | 'protected'] [((TYPE ['&']) | '~')] IDENTIFIER PARAMLIST ['const'] FUNCATTR (';' | STATBLOCK)
+LISTENTRY     ::= (('repeat' | 'repeat_same') (('{' LISTENTRY '}') | TYPE)) | (TYPE {',' TYPE})
+LISTPATTERN   ::= '{' LISTENTRY {',' LISTENTRY} '}'
+FUNC          ::= {'shared' | 'external'} ['private' | 'protected'] [((TYPE ['&']) | '~')] IDENTIFIER PARAMLIST [LISTPATTERN] ['const'] FUNCATTR (';' | STATBLOCK)
 INTERFACE     ::= {'external' | 'shared'} 'interface' IDENTIFIER (';' | ([':' IDENTIFIER {',' IDENTIFIER}] '{' {VIRTPROP | INTFMTHD} '}'))
 VAR           ::= ['private' | 'protected'] TYPE IDENTIFIER [( '=' (INITLIST | ASSIGN)) | ARGLIST] {',' IDENTIFIER [( '=' (INITLIST | ASSIGN)) | ARGLIST]} ';'
 IMPORT        ::= 'import' TYPE ['&'] IDENTIFIER PARAMLIST FUNCATTR 'from' STRING ';'
@@ -12,8 +14,8 @@ VIRTPROP      ::= ['private' | 'protected'] TYPE ['&'] IDENTIFIER '{' {('get' | 
 MIXIN         ::= 'mixin' CLASS
 INTFMTHD      ::= TYPE ['&'] IDENTIFIER PARAMLIST ['const'] ';'
 STATBLOCK     ::= '{' {VAR | STATEMENT} '}'
-PARAMLIST     ::= '(' ['void' | (TYPE TYPEMOD [IDENTIFIER] ['=' [EXPR | 'void']] {',' TYPE TYPEMOD [IDENTIFIER] ['...' | ('=' [EXPR | 'void']])})] ')'
-TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] [+] ['if_handle_then_const']]
+PARAMLIST     ::= '(' ['void' | (TYPE TYPEMOD [IDENTIFIER] ['=' [EXPR | 'void']] {',' TYPE TYPEMOD [IDENTIFIER] ['...' | ('=' [EXPR | 'void'])]})] ')'
+TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] ['+'] ['if_handle_then_const']]
 TYPE          ::= ['const'] SCOPE DATATYPE ['<' TYPE {',' TYPE} '>'] { ('[' ']') | ('@' ['const']) }
 INITLIST      ::= '{' [ASSIGN | INITLIST] {',' [ASSIGN | INITLIST]} '}'
 SCOPE         ::= ['::'] {IDENTIFIER '::'} [IDENTIFIER ['<' TYPE {',' TYPE} '>'] '::']
@@ -37,7 +39,7 @@ EXPRTERM      ::= ([TYPE '='] INITLIST) | ({EXPRPREOP} EXPRVALUE {EXPRPOSTOP})
 EXPRVALUE     ::= 'void' | CONSTRUCTCALL | FUNCCALL | VARACCESS | CAST | LITERAL | '(' ASSIGN ')' | LAMBDA
 CONSTRUCTCALL ::= TYPE ARGLIST
 EXPRPREOP     ::= '-' | '+' | '!' | '++' | '--' | '~' | '@'
-EXPRPOSTOP    ::= ('.' (FUNCCALL | IDENTIFIER)) | ('[' [IDENTIFIER ':'] ASSIGN {',' [IDENTIFIER ':' ASSIGN} ']') | ARGLIST | '++' | '--'
+EXPRPOSTOP    ::= ('.' (FUNCCALL | IDENTIFIER)) | ('[' [IDENTIFIER ':'] ASSIGN {',' [IDENTIFIER ':'] ASSIGN} ']') | ARGLIST | '++' | '--'
 CAST          ::= 'cast' '<' TYPE '>' '(' ASSIGN ')'
 LAMBDA        ::= 'function' '(' [[TYPE TYPEMOD] [IDENTIFIER] {',' [TYPE TYPEMOD] [IDENTIFIER]}] ')' STATBLOCK
 LITERAL       ::= NUMBER | STRING | BITS | 'true' | 'false' | 'null'

--- a/server/src/compiler_analyzer/analyzer.ts
+++ b/server/src/compiler_analyzer/analyzer.ts
@@ -219,7 +219,7 @@ export function analyzeParamList(scope: SymbolScope, paramList: NodeParamList) {
     }
 }
 
-// BNF: TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] [+] ['if_handle_then_const']]
+// BNF: TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] ['+'] ['if_handle_then_const']]
 
 // BNF: TYPE          ::= ['const'] SCOPE DATATYPE ['<' TYPE {',' TYPE} '>'] { ('[' ']') | ('@' ['const']) }
 export function analyzeType(scope: SymbolScope, nodeType: NodeType): ResolvedType | undefined {

--- a/server/src/compiler_analyzer/hoist.ts
+++ b/server/src/compiler_analyzer/hoist.ts
@@ -487,7 +487,7 @@ function hoistParamList(scope: SymbolScope, paramList: NodeParamList) {
     return resolvedTypes;
 }
 
-// BNF: TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] [+] ['if_handle_then_const']]
+// BNF: TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] ['+'] ['if_handle_then_const']]
 // BNF: TYPE          ::= ['const'] SCOPE DATATYPE ['<' TYPE {',' TYPE} '>'] { ('[' ']') | ('@' ['const']) }
 // BNF: INITLIST      ::= '{' [ASSIGN | INITLIST] {',' [ASSIGN | INITLIST]} '}'
 // BNF: SCOPE         ::= ['::'] {IDENTIFIER '::'} [IDENTIFIER ['<' TYPE {',' TYPE} '>'] '::']

--- a/server/src/compiler_parser/nodes.ts
+++ b/server/src/compiler_parser/nodes.ts
@@ -97,6 +97,7 @@ export enum NodeName {
     Bits = 'Bits',
     Comment = 'Comment',
     Whitespace = 'Whitespace',
+	ListPattern = 'ListPattern'
 }
 
 export interface NodesBase {
@@ -173,6 +174,7 @@ export interface NodeFunc extends NodesBase {
     readonly funcAttr: FunctionAttribute | undefined;
     readonly statBlock: NodeStatBlock;
     readonly typeTemplates: NodeType[];
+	readonly listPattern: NodeListPattern | undefined
 }
 
 export interface FuncHeadReturnValue {
@@ -274,6 +276,48 @@ export interface NodeStatBlock extends NodesBase {
     readonly statementList: (NodeVar | NodeStatement)[];
 }
 
+export enum NodeListOp {
+	StartList = 'StartList',
+	EndList = 'EndList',
+	Repeat = 'Repeat',
+	RepeatSame = 'RepeatSame',
+	Type = 'Type'
+}
+
+export interface NodeListOperator {
+	readonly operator: NodeListOp
+}
+
+export interface NodeListOperatorStartList extends NodeListOperator {
+	readonly operator: NodeListOp.StartList
+}
+
+export interface NodeListOperatorEndList extends NodeListOperator {
+	readonly operator: NodeListOp.EndList
+}
+
+export interface NodeListOperatorRepeat extends NodeListOperator {
+	readonly operator: NodeListOp.Repeat
+}
+
+export interface NodeListOperatorRepeatSame extends NodeListOperator {
+	readonly operator: NodeListOp.RepeatSame
+}
+
+export interface NodeListOperatorType extends NodeListOperator {
+	readonly operator: NodeListOp.Type,
+	readonly type: NodeType
+}
+
+export type NodeListValidOperators = NodeListOperatorType | NodeListOperatorRepeatSame | NodeListOperatorRepeat | NodeListOperatorEndList | NodeListOperatorStartList;
+
+// BNF: LISTENTRY     ::= (['repeat' | 'repeat_same'] (('{' LISTENTRY '}') | TYPE)) | TYPE {',' TYPE}
+// BNF: LISTPATTERN   ::= '{' LISTENTRY {',' LISTENTRY} '}'
+export interface NodeListPattern extends NodesBase {
+	readonly nodeName: NodeName.ListPattern;
+	readonly operators: NodeListValidOperators[]
+}
+
 // BNF: PARAMLIST     ::= '(' ['void' | (TYPE TYPEMOD [IDENTIFIER] ['=' [EXPR | 'void']] {',' TYPE TYPEMOD [IDENTIFIER] ['...' | ('=' [EXPR | 'void']])})] ')'
 export type NodeParamList = ParsedTypeIdentifier[];
 
@@ -285,7 +329,7 @@ export interface ParsedTypeIdentifier {
     readonly isVariadic: boolean
 }
 
-// BNF: TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] [+] ['if_handle_then_const']]
+// BNF: TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] ['+'] ['if_handle_then_const']]
 
 // BNF: TYPE          ::= ['const'] SCOPE DATATYPE ['<' TYPE {',' TYPE} '>'] { ('[' ']') | ('@' ['const']) }
 export interface NodeType extends NodesBase {

--- a/server/src/compiler_parser/nodes.ts
+++ b/server/src/compiler_parser/nodes.ts
@@ -97,7 +97,7 @@ export enum NodeName {
     Bits = 'Bits',
     Comment = 'Comment',
     Whitespace = 'Whitespace',
-	ListPattern = 'ListPattern'
+    ListPattern = 'ListPattern'
 }
 
 export interface NodesBase {
@@ -174,7 +174,7 @@ export interface NodeFunc extends NodesBase {
     readonly funcAttr: FunctionAttribute | undefined;
     readonly statBlock: NodeStatBlock;
     readonly typeTemplates: NodeType[];
-	readonly listPattern: NodeListPattern | undefined
+    readonly listPattern: NodeListPattern | undefined
 }
 
 export interface FuncHeadReturnValue {
@@ -277,36 +277,36 @@ export interface NodeStatBlock extends NodesBase {
 }
 
 export enum NodeListOp {
-	StartList = 'StartList',
-	EndList = 'EndList',
-	Repeat = 'Repeat',
-	RepeatSame = 'RepeatSame',
-	Type = 'Type'
+    StartList = 'StartList',
+    EndList = 'EndList',
+    Repeat = 'Repeat',
+    RepeatSame = 'RepeatSame',
+    Type = 'Type'
 }
 
 export interface NodeListOperator {
-	readonly operator: NodeListOp
+    readonly operator: NodeListOp
 }
 
 export interface NodeListOperatorStartList extends NodeListOperator {
-	readonly operator: NodeListOp.StartList
+    readonly operator: NodeListOp.StartList
 }
 
 export interface NodeListOperatorEndList extends NodeListOperator {
-	readonly operator: NodeListOp.EndList
+    readonly operator: NodeListOp.EndList
 }
 
 export interface NodeListOperatorRepeat extends NodeListOperator {
-	readonly operator: NodeListOp.Repeat
+    readonly operator: NodeListOp.Repeat
 }
 
 export interface NodeListOperatorRepeatSame extends NodeListOperator {
-	readonly operator: NodeListOp.RepeatSame
+    readonly operator: NodeListOp.RepeatSame
 }
 
 export interface NodeListOperatorType extends NodeListOperator {
-	readonly operator: NodeListOp.Type,
-	readonly type: NodeType
+    readonly operator: NodeListOp.Type,
+    readonly type: NodeType
 }
 
 export type NodeListValidOperators = NodeListOperatorType | NodeListOperatorRepeatSame | NodeListOperatorRepeat | NodeListOperatorEndList | NodeListOperatorStartList;
@@ -314,8 +314,8 @@ export type NodeListValidOperators = NodeListOperatorType | NodeListOperatorRepe
 // BNF: LISTENTRY     ::= (['repeat' | 'repeat_same'] (('{' LISTENTRY '}') | TYPE)) | TYPE {',' TYPE}
 // BNF: LISTPATTERN   ::= '{' LISTENTRY {',' LISTENTRY} '}'
 export interface NodeListPattern extends NodesBase {
-	readonly nodeName: NodeName.ListPattern;
-	readonly operators: NodeListValidOperators[]
+    readonly nodeName: NodeName.ListPattern;
+    readonly operators: NodeListValidOperators[]
 }
 
 // BNF: PARAMLIST     ::= '(' ['void' | (TYPE TYPEMOD [IDENTIFIER] ['=' [EXPR | 'void']] {',' TYPE TYPEMOD [IDENTIFIER] ['...' | ('=' [EXPR | 'void']])})] ')'

--- a/server/src/compiler_parser/parser.ts
+++ b/server/src/compiler_parser/parser.ts
@@ -500,7 +500,7 @@ function parseListEntry(parser: ParserState, operators: NodeListValidOperators[]
                     operator: NodeListOp.EndList
                 });
             }
-        } else if (parser.next().text === 'repeat' || parser.next().text === 'repeat_once') {
+        } else if (parser.next().text === 'repeat' || parser.next().text === 'repeat_same') {
             parser.commit(HighlightForToken.Keyword);
 
             operators.push({
@@ -527,6 +527,8 @@ function parseListEntry(parser: ParserState, operators: NodeListValidOperators[]
 
 // BNF: LISTPATTERN   ::= '{' LISTENTRY {',' LISTENTRY} '}'
 function parseListPattern(parser: ParserState): NodeListPattern | undefined {
+    if (parser.next().location.path.endsWith('as.predefined') === false) return undefined;
+
     const rangeStart = parser.next();
 
     if (parser.next().text !== '{') {

--- a/server/src/compiler_parser/parser.ts
+++ b/server/src/compiler_parser/parser.ts
@@ -551,7 +551,7 @@ function parseListPattern(parser: ParserState): NodeListPattern | undefined {
         }
     }
 
-    if (parser.next().text !== '}') {
+    if (parser.next().text !== '}' || listOperations.length === 0) {
         parser.backtrack(rangeStart);
         return undefined;
     }

--- a/server/src/formatter/formatter.ts
+++ b/server/src/formatter/formatter.ts
@@ -454,7 +454,7 @@ function formatParenthesesBlock(format: FormatterState, action: () => void, cond
     formatTargetBy(format, ')', {condenseLeft: true});
 }
 
-// BNF: TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] [+] ['if_handle_then_const']]
+// BNF: TYPEMOD       ::= ['&' ['in' | 'out' | 'inout'] ['+'] ['if_handle_then_const']]
 function formatTypeMod(format: FormatterState) {
     const next = formatMoveToNonComment(format);
     if (next === undefined) return;


### PR DESCRIPTION
Parses list factories into a node which just contains a list of 'operators' (flattened version of the list). Currently doesn't actually verify that the list is any good, and doesn't support analysis, but at least stops errors in predefined.as from lists.