### PR TITLE
Feature/inline hint preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,12 @@
                     "default": false,
                     "description": "Whether your codebase supports the foreach construct."
                 },
+                "angelScript.experimental.inlineHints": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Provide inline hints (preview)"
+                },
                 "angelScript.formatter.maxBlankLines": {
                     "scope": "window",
                     "type": "number",

--- a/server/src/compiler_analyzer/analyzer.ts
+++ b/server/src/compiler_analyzer/analyzer.ts
@@ -40,7 +40,7 @@ import {
     NodeWhile
 } from "../compiler_parser/nodes";
 import {
-    isDefinitionNodeClassOrInterface,
+    isNodeClassOrInterface,
     SymbolFunction,
     SymbolFunctionHolder,
     SymbolObjectHolder,
@@ -66,7 +66,7 @@ import {
 import {complementHintForScope, ComplementKind} from "./complementHint";
 import {
     findSymbolWithParent,
-    getSymbolAndScopeIfExist, isAllowedToAccessInstanceMember,
+    getSymbolAndScopeIfExist, canAccessInstanceMember,
     isResolvedAutoType,
     stringifyResolvedType,
     stringifyResolvedTypes
@@ -817,7 +817,7 @@ function analyzeExprPostOp1(scope: SymbolScope, exprPostOp: NodeExprPostOp1, exp
     const identifier = isMemberMethod ? member.identifier : member;
     if (identifier === undefined) return undefined;
 
-    if (isDefinitionNodeClassOrInterface(exprValue.typeOrFunc.linkedNode) === false) {
+    if (isNodeClassOrInterface(exprValue.typeOrFunc.linkedNode) === false) {
         analyzerDiagnostic.add(identifier.location, `'${identifier.text}' is not a member.`);
         return undefined;
     }
@@ -1054,7 +1054,7 @@ function analyzeVariableAccess(
         return undefined;
     }
 
-    if (isAllowedToAccessInstanceMember(checkingScope, declared.symbol) === false) {
+    if (canAccessInstanceMember(checkingScope, declared.symbol) === false) {
         analyzerDiagnostic.add(varIdentifier.location, `'${varIdentifier.text}' is not public member.`);
         return undefined;
     }

--- a/server/src/compiler_analyzer/symbolObject.ts
+++ b/server/src/compiler_analyzer/symbolObject.ts
@@ -6,7 +6,8 @@ import {
     NodeFuncDef,
     NodeInterface,
     NodeIntfMethod,
-    NodeName
+    NodeName,
+    NodesBase
 } from "../compiler_parser/nodes";
 import {Mutable} from "../utils/utilities";
 import {ResolvedType} from "./resolvedType";
@@ -18,7 +19,7 @@ import assert = require("node:assert");
  */
 export type TypeDefinitionNode = NodeEnum | NodeClass | NodeInterface;
 
-export function isDefinitionNodeClassOrInterface(type: TypeDefinitionNode | undefined): type is NodeClass {
+export function isNodeClassOrInterface(type: NodesBase | undefined): type is NodeClass {
     if (type === undefined) return false;
     return type.nodeName === NodeName.Class || type.nodeName === NodeName.Interface;
 }

--- a/server/src/compiler_analyzer/symbolUtils.ts
+++ b/server/src/compiler_analyzer/symbolUtils.ts
@@ -93,7 +93,7 @@ export function findSymbolWithParent(scope: SymbolScope, identifier: string): Sy
  * @param accessingScope
  * @param instanceMember
  */
-export function isAllowedToAccessInstanceMember(accessingScope: SymbolScope, instanceMember: SymbolObjectHolder): boolean {
+export function canAccessInstanceMember(accessingScope: SymbolScope, instanceMember: SymbolObjectHolder): boolean {
     const instanceMemberSymbol = instanceMember.toList()[0]; // FIXME: What if there are multiple functions?
 
     if (instanceMemberSymbol instanceof SymbolType) return true;

--- a/server/src/compiler_analyzer/typeConversion.ts
+++ b/server/src/compiler_analyzer/typeConversion.ts
@@ -1,6 +1,6 @@
 import {ResolvedType} from "./resolvedType";
 import {resolveActiveScope} from "./symbolScope";
-import {isDefinitionNodeClassOrInterface, SymbolFunction, SymbolType} from "./symbolObject";
+import {isNodeClassOrInterface, SymbolFunction, SymbolType} from "./symbolObject";
 import {NodeName} from "../compiler_parser/nodes";
 import {resolvedBuiltinInt, resolvedBuiltinUInt} from "./builtinType";
 import assert = require("node:assert");
@@ -391,7 +391,7 @@ export function canDownCast(srcType: SymbolType, destType: SymbolType): boolean 
 
     if (srcType.linkedNode === destType.linkedNode) return true;
 
-    if (isDefinitionNodeClassOrInterface(srcNode)) {
+    if (isNodeClassOrInterface(srcNode)) {
         if (srcType.baseList === undefined) return false;
 
         for (const srcBase of srcType.baseList) {

--- a/server/src/compiler_tokenizer/textLocation.ts
+++ b/server/src/compiler_tokenizer/textLocation.ts
@@ -64,6 +64,10 @@ export class TextRange implements languageserver.Range {
     ) {
     }
 
+    public static create(range: languageserver.Range): TextRange {
+        return new TextRange(TextPosition.create(range.start), TextPosition.create(range.end));
+    }
+
     public positionInRange(position: languageserver.Position): boolean {
         if (position.line < this.start.line || position.line > this.end.line) return false;
         if (position.line === this.start.line && position.character < this.start.character) return false;

--- a/server/src/compiler_tokenizer/textLocation.ts
+++ b/server/src/compiler_tokenizer/textLocation.ts
@@ -76,6 +76,11 @@ export class TextRange implements languageserver.Range {
         return true;
     }
 
+    public intersects(other: TextRange): boolean {
+        if (this.end.isLessThan(other.start) || other.end.isLessThan(this.start)) return false;
+        return true;
+    }
+
     public clone(): TextRange {
         return Object.assign(Object.create(Object.getPrototypeOf(this)), this);
     }

--- a/server/src/compiler_tokenizer/textLocation.ts
+++ b/server/src/compiler_tokenizer/textLocation.ts
@@ -26,9 +26,9 @@ export class TextPosition implements languageserver.Position {
     /**
      * Returns true if this position is ahead of the other position.
      */
-    public isAheadOf(other: languageserver.Position): boolean {
+    public isLessThan(other: languageserver.Position): boolean {
         if (this.line < other.line) return true;
-        return this.isSameLine(other) && this.character < other.character;
+        return this.line === other.line && this.character < other.character;
     }
 
     public formatWithColon(): string {

--- a/server/src/core/settings.ts
+++ b/server/src/core/settings.ts
@@ -9,6 +9,9 @@ export interface LanguageServerSettings {
     explicitPropertyAccessor: boolean;
     supportsForEach: boolean;
     supportsTypedEnumerations: boolean;
+    experimental: {
+        inlineHints: boolean;
+    };
     builtinStringTypes: string[];
     builtinArrayType: string,
     formatter: {
@@ -28,6 +31,9 @@ const defaultSettings: LanguageServerSettings = {
     explicitPropertyAccessor: false,
     supportsForEach: false,
     supportsTypedEnumerations: false,
+    experimental: {
+        inlineHints: false
+    },
     builtinStringTypes: ["string", "String"],
     builtinArrayType: "array",
     formatter: {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -31,7 +31,7 @@ import {changeGlobalSettings} from "./core/settings";
 import {formatFile} from "./formatter/formatter";
 import {stringifySymbolObject} from "./compiler_analyzer/symbolUtils";
 import {provideSignatureHelp} from "./services/signatureHelp";
-import {TextPosition, TextRange} from "./compiler_tokenizer/textLocation";
+import {TextLocation, TextPosition, TextRange} from "./compiler_tokenizer/textLocation";
 import {provideInlineHint} from "./services/inlineHint";
 
 // Create a connection for the server, using Node's IPC as a transport.
@@ -157,9 +157,12 @@ connection.languages.semanticTokens.on((params) => {
 // -----------------------------------------------
 // Inlay Hints Provider
 connection.languages.inlayHint.on((params) => {
+    const uri = params.textDocument.uri;
+    const range = TextRange.create(params.range);
+
     return provideInlineHint(
-        getInspectedRecord(params.textDocument.uri).analyzerScope.globalScope,
-        TextRange.create(params.range)
+        getInspectedRecord(uri).analyzerScope.globalScope,
+        new TextLocation(uri, range.start, range.end)
     );
 });
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -27,7 +27,7 @@ import {provideSemanticTokens} from "./services/semanticTokens";
 import {provideReferences} from "./services/reference";
 import {TextEdit} from "vscode-languageserver-types/lib/esm/main";
 import {Location} from "vscode-languageserver";
-import {changeGlobalSettings} from "./core/settings";
+import {changeGlobalSettings, getGlobalSettings} from "./core/settings";
 import {formatFile} from "./formatter/formatter";
 import {stringifySymbolObject} from "./compiler_analyzer/symbolUtils";
 import {provideSignatureHelp} from "./services/signatureHelp";
@@ -157,6 +157,8 @@ connection.languages.semanticTokens.on((params) => {
 // -----------------------------------------------
 // Inlay Hints Provider
 connection.languages.inlayHint.on((params) => {
+    if (!getGlobalSettings().experimental.inlineHints) return []; // TODO: Delete after the preview ends.
+
     const uri = params.textDocument.uri;
     const range = TextRange.create(params.range);
 

--- a/server/src/services/completion.ts
+++ b/server/src/services/completion.ts
@@ -13,7 +13,7 @@ import {
 import {ComplementHint, ComplementKind} from "../compiler_analyzer/complementHint";
 import {findScopeContainingPosition} from "./serviceHelper";
 import {TextPosition} from "../compiler_tokenizer/textLocation";
-import {isAllowedToAccessInstanceMember} from "../compiler_analyzer/symbolUtils";
+import {canAccessInstanceMember} from "../compiler_analyzer/symbolUtils";
 
 /**
  * Returns the completion candidates for the specified position.
@@ -70,7 +70,7 @@ function getCompletionMembersInScope(globalScope: SymbolScope, caretScope: Symbo
     // Completion of symbols in the scope
     for (const [symbolName, symbol] of symbolScope.symbolTable) {
         if (isSymbolInstanceMember(symbol) === false) continue;
-        if (isAllowedToAccessInstanceMember(caretScope, symbol) === false) continue;
+        if (canAccessInstanceMember(caretScope, symbol) === false) continue;
 
         items.push({
             label: symbolName,

--- a/server/src/services/inlineHint.ts
+++ b/server/src/services/inlineHint.ts
@@ -1,13 +1,118 @@
-import {SymbolScope} from "../compiler_analyzer/symbolScope";
-import {TextRange} from "../compiler_tokenizer/textLocation";
+import {isAnonymousIdentifier, SymbolScope} from "../compiler_analyzer/symbolScope";
+import {TextLocation} from "../compiler_tokenizer/textLocation";
 import {InlayHint} from "vscode-languageserver-protocol";
+import {isNodeClassOrInterface} from "../compiler_analyzer/symbolObject";
 
-export function provideInlineHint(globalScope: SymbolScope, range: TextRange): InlayHint[] {
-    return [{
-        position: {
-            line: 0,
-            character: 0
-        },
-        label: 'TODO'
-    }];
+export function provideInlineHint(globalScope: SymbolScope, location: TextLocation): InlayHint[] {
+    // TODO: Implement more hints
+
+    return hintOperatorOverloadDefinition(globalScope, location);
 }
+
+// -----------------------------------------------
+
+function hintOperatorOverloadDefinition(scope: SymbolScope, location: TextLocation) {
+    const result: InlayHint[] = [];
+    if (scope.linkedNode !== undefined && isNodeClassOrInterface(scope.linkedNode)) {
+        if (scope.linkedNode.nodeRange.path !== location.path) {
+            return [];
+        }
+
+        if (scope.linkedNode.nodeRange.getBoundingLocation().intersects(location) === false) {
+            // Skip if the class definition is not in the given location
+            return [];
+        }
+
+        // Iterate over class members in scope
+        for (const [key, symbolHolder] of scope.symbolTable) {
+            if (symbolHolder.isFunctionHolder() === false) continue;
+
+            const operatorText = operatorOverloads.get(key);
+            if (operatorText === undefined) continue;
+
+            for (const symbol of symbolHolder.toList()) {
+                if (symbol.linkedNode === undefined) continue;
+
+                if (symbol.linkedNode.nodeRange.getBoundingLocation().intersects(location) === false) {
+                    // Skip if the operator overload definition is not in the given location
+                    continue;
+                }
+
+                // Push the operator overload hint, e.g., "int opAdd() 'operator +'"
+                const identifier = symbol.linkedNode.identifier;
+                result.push({
+                    position: identifier.location.end,
+                    label: `: ${operatorText}`
+                });
+            }
+        }
+    }
+
+    for (const childScope of scope.childScopeTable.values()) {
+        if (isAnonymousIdentifier(childScope.key)) continue;
+
+        result.push(...hintOperatorOverloadDefinition(childScope, location));
+    }
+
+    return result;
+}
+
+const operatorOverloads = new Map([
+    // Prefix unary operators
+    ['opNeg', '-'],
+    ['opCom', '~'],
+    ['opPreInc', '++'],
+    ['opPreDec', '--'],
+
+    // Postfix unary operators
+    ['opPostInc', '++'],
+    ['opPostDec', '--'],
+
+    // Comparison operators
+    ['opEquals', '==, !=, is, !is'],
+    ['opCmp', '<, <=, >, >='],
+
+    // Assignment operators
+    ['opAssign', '='],
+    ['opAddAssign', '+='],
+    ['opSubAssign', '-='],
+    ['opMulAssign', '*='],
+    ['opDivAssign', '/='],
+    ['opModAssign', '%='],
+    ['opPowAssign', '**='],
+    ['opAndAssign', '&='],
+    ['opOrAssign', '|='],
+    ['opXorAssign', '^='],
+    ['opShlAssign', '<<='],
+    ['opShrAssign', '>>='],
+    ['opUShrAssign', '>>>='],
+
+    // Binary operators
+    ['opAdd', '+'],
+    ['opSub', '-'],
+    ['opMul', '*'],
+    ['opDiv', '/'],
+    ['opMod', '%'],
+    ['opPow', '**'],
+    ['opAnd', '&'],
+    ['opOr', '|'],
+    ['opXor', '^'],
+    ['opShl', '<<'],
+    ['opShr', '>>'],
+    ['opUShr', '>>>'],
+
+    // Index operators
+    ['opIndex', '[]'],
+    ['get_opIndex', '[] get'],
+    ['set_opIndex', '[] set'],
+
+    // Functor operator
+    ['opCall', '()'],
+
+    // Type conversion operators
+    ['constructor', 'type(expr)'],
+    ['opConv', 'type(expr)'],
+    ['opImplConv', 'type(expr)'],
+    ['opCast', 'cast<type>(expr)'],
+    ['opImplCast', 'cast<type>(expr)'],
+]);

--- a/server/src/services/inlineHint.ts
+++ b/server/src/services/inlineHint.ts
@@ -1,0 +1,13 @@
+import {SymbolScope} from "../compiler_analyzer/symbolScope";
+import {TextRange} from "../compiler_tokenizer/textLocation";
+import {InlayHint} from "vscode-languageserver-protocol";
+
+export function provideInlineHint(globalScope: SymbolScope, range: TextRange): InlayHint[] {
+    return [{
+        position: {
+            line: 0,
+            character: 0
+        },
+        label: 'TODO'
+    }];
+}

--- a/server/src/services/inlineHint.ts
+++ b/server/src/services/inlineHint.ts
@@ -42,7 +42,7 @@ function hintOperatorOverloadDefinition(scope: SymbolScope, location: TextLocati
                 const identifier = symbol.linkedNode.identifier;
                 result.push({
                     position: identifier.location.end,
-                    label: `: ${operatorText}`
+                    label: `: ${operatorText} `
                 });
             }
         }
@@ -89,30 +89,41 @@ const operatorOverloads = new Map([
 
     // Binary operators
     ['opAdd', '+'],
+    ['opAdd_r', '+'],
     ['opSub', '-'],
+    ['opSub_r', '-'],
     ['opMul', '*'],
+    ['opMul_r', '*'],
     ['opDiv', '/'],
+    ['opDiv_r', '/'],
     ['opMod', '%'],
+    ['opMod_r', '%'],
     ['opPow', '**'],
+    ['opPow_r', '**'],
     ['opAnd', '&'],
+    ['opAnd_r', '&'],
     ['opOr', '|'],
+    ['opOr_r', '|'],
     ['opXor', '^'],
+    ['opXor_r', '^'],
     ['opShl', '<<'],
+    ['opShl_r', '<<'],
     ['opShr', '>>'],
+    ['opShr_r', '>>'],
     ['opUShr', '>>>'],
+    ['opUShr_r', '>>>'],
 
     // Index operators
-    ['opIndex', '[]'],
-    ['get_opIndex', '[] get'],
-    ['set_opIndex', '[] set'],
+    ['opIndex', '[...]'],
+    ['get_opIndex', '[...]'],
+    ['set_opIndex', '[...]'],
 
     // Functor operator
-    ['opCall', '()'],
+    ['opCall', '(...)'],
 
     // Type conversion operators
-    ['constructor', 'type(expr)'],
-    ['opConv', 'type(expr)'],
-    ['opImplConv', 'type(expr)'],
-    ['opCast', 'cast<type>(expr)'],
-    ['opImplCast', 'cast<type>(expr)'],
+    ['opConv', '(...) -> (T)'],
+    ['opImplConv', '(...) -> (T)'],
+    ['opCast', 'cast<T>(...)'],
+    ['opImplCast', 'cast<T>(...)'],
 ]);

--- a/server/src/services/signatureHelp.ts
+++ b/server/src/services/signatureHelp.ts
@@ -54,7 +54,7 @@ function getFunctionSignature(hint: ComplementCallerArgument, expectedCallee: Sy
         if (i > 0) signatureLabel += ', ';
         signatureLabel += label;
 
-        if (i < hint.passingRanges.length && caret.isAheadOf(hint.passingRanges[i].start.location.start) === false) {
+        if (i < hint.passingRanges.length && caret.isLessThan(hint.passingRanges[i].start.location.start) === false) {
             activeIndex = i;
             if (hint.passingRanges[i].end.next?.text === ',') activeIndex++;
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/664d8d53-4f45-401a-ae83-97df69b30eb2)

Add experimental inline hints to operator definition.
This is still a preview (because line breaks cause undesirable behavior), so it is set to disabled by default.
