### PR TITLE
Add super basic debugging support

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
+				"@vscode/debugadapter": "^1.61.0",
+				"@vscode/debugprotocol": "^1.61.0",
 				"vscode-languageclient": "^9.0.1"
 			},
 			"devDependencies": {
@@ -33,6 +35,24 @@
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.1.tgz",
 			"integrity": "sha512-emg7wdsTFzdi+elvoyoA+Q8keEautdQHyY5LNmHVM4PTpY8JgOTVADrGVyXGepJ6dVW2OS5/xnLUWh+nZxvdiA==",
 			"dev": true
+		},
+		"node_modules/@vscode/debugadapter": {
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+			"integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
+			"license": "MIT",
+			"dependencies": {
+				"@vscode/debugprotocol": "1.68.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@vscode/debugprotocol": {
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+			"integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
+			"license": "MIT"
 		},
 		"node_modules/@vscode/test-electron": {
 			"version": "2.3.9",
@@ -312,6 +332,19 @@
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.1.tgz",
 			"integrity": "sha512-emg7wdsTFzdi+elvoyoA+Q8keEautdQHyY5LNmHVM4PTpY8JgOTVADrGVyXGepJ6dVW2OS5/xnLUWh+nZxvdiA==",
 			"dev": true
+		},
+		"@vscode/debugadapter": {
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+			"integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
+			"requires": {
+				"@vscode/debugprotocol": "1.68.0"
+			}
+		},
+		"@vscode/debugprotocol": {
+			"version": "1.68.0",
+			"resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+			"integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg=="
 		},
 		"@vscode/test-electron": {
 			"version": "2.3.9",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,9 @@
 		"vscode": "^1.75.0"
 	},
 	"dependencies": {
-		"vscode-languageclient": "^9.0.1"
+		"vscode-languageclient": "^9.0.1",
+        "@vscode/debugadapter": "^1.61.0",
+        "@vscode/debugprotocol": "^1.61.0"
 	},
 	"devDependencies": {
 		"@types/vscode": "^1.75.1",

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import {workspace, ExtensionContext, commands, window, WorkspaceEdit, Range, Position} from 'vscode';
+import {workspace, ExtensionContext, commands, debug, window, WorkspaceEdit, Range, Position, DebugConfigurationProvider, WorkspaceFolder, DebugConfiguration, CancellationToken, ProviderResult} from 'vscode';
 
 import {
     LanguageClient,
@@ -68,6 +68,28 @@ export function deactivate(): Thenable<void> | undefined {
 
 // -----------------------------------------------
 
+class AngelScriptConfigurationProvider implements DebugConfigurationProvider {
+    resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
+        return config;
+    }
+
+    resolveDebugConfigurationWithSubstitutedVariables(folder: WorkspaceFolder | undefined, config: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
+        return config;
+    }
+}
+
+class AngelScriptDebugAdapterServerDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+    async createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): Promise<vscode.DebugAdapterDescriptor> {
+        return new vscode.DebugAdapterServer(session.configuration.port, session.configuration.address);
+    }
+}
+
+class AngelScriptDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactory {
+	createDebugAdapterTracker(session: vscode.DebugSession): ProviderResult<vscode.DebugAdapterTracker> {
+		return {};
+	}
+}
+
 function subscribeCommands(context: ExtensionContext) {
     context.subscriptions.push(
         commands.registerCommand('angelScript.debug.printGlobalScope', async () => {
@@ -81,4 +103,7 @@ function subscribeCommands(context: ExtensionContext) {
             }
         })
     );
+    context.subscriptions.push(debug.registerDebugConfigurationProvider("angel-lsp-dap", new AngelScriptConfigurationProvider()));
+    context.subscriptions.push(debug.registerDebugAdapterDescriptorFactory("angel-lsp-dap", new AngelScriptDebugAdapterServerDescriptorFactory()));
+    context.subscriptions.push(debug.registerDebugAdapterTrackerFactory("angel-lsp-dap", new AngelScriptDebugAdapterTrackerFactory()));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,18 @@
 {
     "name": "angel-lsp",
-    "version": "0.1.0",
+    "version": "0.3.37",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "angel-lsp",
-            "version": "0.1.0",
+            "version": "0.3.37",
             "hasInstallScript": true,
             "license": "MIT",
+            "dependencies": {
+                "@vscode/debugadapter": "^1.61.0",
+                "@vscode/debugprotocol": "^1.61.0"
+            },
             "devDependencies": {
                 "@types/mocha": "^10.0.6",
                 "@types/node": "^18.14.6",
@@ -491,6 +495,24 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true
+        },
+        "node_modules/@vscode/debugadapter": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.68.0.tgz",
+            "integrity": "sha512-D6gk5Fw2y4FV8oYmltoXpj+VAZexxJFopN/mcZ6YcgzQE9dgq2L45Aj3GLxScJOD6GeLILcxJIaA8l3v11esGg==",
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/debugprotocol": "1.68.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@vscode/debugprotocol": {
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.68.0.tgz",
+            "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==",
+            "license": "MIT"
         },
         "node_modules/acorn": {
             "version": "8.11.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     },
     "publisher": "sashi0034",
     "categories": [
-        "Programming Languages"
+        "Programming Languages",
+        "Debuggers"
     ],
     "keywords": [
         "angelscript"
@@ -26,7 +27,8 @@
     "activationEvents": [
         "onLanguage:angelscript",
         "onLanguage:angelscript-predefined",
-        "workspaceContains:**/*.as"
+        "workspaceContains:**/*.as",
+		"onDebug"
     ],
     "main": "./client/out/extension",
     "contributes": {
@@ -192,7 +194,61 @@
                     "description": "Traces the communication between VS Code and the language server."
                 }
             }
-        }
+        },
+        "breakpoints": [
+            {
+                "language": "angelscript"
+            }
+        ],
+        "debuggers": [
+            {
+                "type": "angel-lsp-dap",
+                "languages": [
+                    "angelscript"
+                ],
+                "label": "AngelScript Debugger (DAP)",
+                "configurationAttributes": {
+                    "attach": {
+                        "properties": {
+                            "address": {
+                                "type": "string",
+                                "description": "IP address of the DAP server to connect to"
+                            },
+                            "port": {
+                                "type": "number",
+                                "description": "Port of the DAP debugger to connect to"
+                            }
+                        },
+                        "required": [
+                            "address",
+                            "port"
+                        ]
+                    }
+                },
+                "initialConfigurations": [
+                    {
+                        "type": "angel-lsp-dap",
+                        "request": "attach",
+                        "name": "Attach to AngelScript DAP server",
+                        "address": "localhost",
+                        "port": 27979
+                    }
+                ],
+                "configurationSnippets": [
+                    {
+                        "label": "AngelScript Debug: Attach",
+                        "description": "Configuration for attaching to a DAP server",
+                        "body": {
+                            "type": "angel-lsp-dap",
+                            "request": "attach",
+                            "name": "Attach to AngelScript DAP server",
+                            "address": "localhost",
+                            "port": 27979
+                        }
+                    }
+                ]
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",
@@ -211,5 +267,9 @@
         "mocha": "^10.3.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
-    }
+    },
+	"dependencies": {
+        "@vscode/debugadapter": "^1.61.0",
+        "@vscode/debugprotocol": "^1.61.0"
+	}
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "lsp-sample-server",
+	"name": "angel-lsp",
 	"version": "1.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "lsp-sample-server",
+			"name": "angel-lsp",
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
Adds the ability to set breakpoints & a default Attach configuration, sets this extension to allow debugging on .as files, and allows attaching to a debug adapter via the socket connector.

This is enough to actually use the extension for debugging; ![](https://i.imgur.com/3rapsvT.png)