### PR TITLE
support for C++14 digit separators

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,12 @@
                     "default": false,
                     "description": "Whether your codebase supports the foreach construct."
                 },
+                "angelScript.supportsDigitSeparators": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether your codebase supports C++14-style digit separators."
+                },
                 "angelScript.characterLiterals": {
                     "scope": "window",
                     "type": "boolean",

--- a/server/src/core/settings.ts
+++ b/server/src/core/settings.ts
@@ -11,6 +11,7 @@ interface LanguageServerSettings {
     supportsForEach: boolean;
     characterLiterals: boolean;
     supportsTypedEnumerations: boolean;
+    supportsDigitSeparators: boolean;
     builtinStringType: string;
     builtinArrayType: string;
     formatter: {
@@ -32,6 +33,7 @@ const defaultSettings: LanguageServerSettings = {
     supportsForEach: false,
     characterLiterals: false,
     supportsTypedEnumerations: false,
+    supportsDigitSeparators: false,
     builtinStringType: "string",
     builtinArrayType: "array",
     formatter: {


### PR DESCRIPTION
This is a PR to allow for C++14-style digit separators.
I've implemented this in AngelScript and sent the patch to the maintainer, but am using it in my local projects already. 

Here's the AngelScript patch if you want to try it with a real compiler:
[number_separators.patch](https://github.com/user-attachments/files/19615281/number_separators.patch)

The little testing suite I've written passes and fails everything that is expected to pass/fail:
(surprisingly, the code preview for C++ seems to fail on one of the valid floats):
```cpp
void main(bool is_cgame)
{
    // sanity
    0xFFFFFFFF;
    1024768;
    -1200;

    // integer passes
    1'000'000;
    1'0'0'0;
    0xFFFF'FFFF;
    0xF'F'F'F;

    // float passes
    1'000.000'000;
    12'44e+1'2;

    // integer fails
    1''000;
    ''100;
    '100;
    100'';
    100';
    
    // float fails
    12'.00;
    123.'00;
    1234.33'e+123;
    1234.33e'+123;
    1234.33e+'123;
}
```