### PR TITLE
Add diagnostic for uninitialized auto variables.

### DIFF
--- a/server/src/compiler_analyzer/analyzer.ts
+++ b/server/src/compiler_analyzer/analyzer.ts
@@ -148,7 +148,15 @@ export function analyzeVar(scope: SymbolScope, nodeVar: NodeVar, isInstanceMembe
 
     for (const declaredVar of nodeVar.variables) {
         const initializer = declaredVar.initializer;
-        if (initializer === undefined) continue;
+        if (initializer === undefined) {
+            if (varType?.isAutoType()) {
+                analyzerDiagnostic.error(
+                    declaredVar.identifier.location,
+                    `Variables declared using 'auto' must be initialized.`
+                );
+            }
+            continue;
+        }
 
         const initType = analyzeVarInitializer(scope, varType, declaredVar.identifier, initializer);
 


### PR DESCRIPTION
This adds a diagnostic, warning about uninitialized auto variables, that will cause compilation to fail. The AngelScript compiler error message says "Unable to resolve auto type" but i think the error message i choose here makes more sense.