### PR TITLE
Add template specialization support and fix generic type resolution

### DIFF
--- a/server/src/compiler_parser/nodesUtils.ts
+++ b/server/src/compiler_parser/nodesUtils.ts
@@ -26,3 +26,13 @@ export function stringifyNodeType(type: NodeType): string {
 export function getIdentifierInNodeType(type: NodeType): TokenObject {
     return type.dataType.identifier;
 }
+
+export function buildTemplateSignature(types: NodeType[]): string {
+    const typeNames = types.map(type => {
+        const identifier = type.dataType.identifier.text;
+        return type.typeTemplates.length > 0
+            ? identifier + buildTemplateSignature(type.typeTemplates)
+            : identifier;
+    });
+    return '<' + typeNames.join(',') + '>';
+}

--- a/server/test/compiler/analyzer/templateSpecialization.spec.ts
+++ b/server/test/compiler/analyzer/templateSpecialization.spec.ts
@@ -1,0 +1,103 @@
+import {expectError, expectSuccess} from "./utils";
+
+describe('analyzer/templateSpecialization', () => {
+    expectSuccess([{
+        uri: 'file:///path/to/as.predefined',
+        content: `
+            class Container<T> {
+                T item;
+            }
+
+            class Player {
+                int health;
+            }
+            `
+    }, {
+        uri: 'file:///path/to/file.as',
+        content: `// Generic type parameter resolves correctly for member access.
+            void main() {
+                Container<Player> container;
+                container.item.health = 100;
+            }
+            `
+    }]);
+
+    expectSuccess([{
+        uri: 'file:///path/to/as.predefined',
+        content: `
+            class Wrapper<T> {
+                T data;
+            }
+
+            class Entity {
+                int x, y;
+            }
+            `
+    }, {
+        uri: 'file:///path/to/file.as',
+        content: `// Nested generic types resolve correctly.
+            void main() {
+                Wrapper<Wrapper<Entity>> nested;
+                nested.data.data.x = 10;
+                nested.data.data.y = 20;
+            }
+            `
+    }]);
+
+    expectSuccess([{
+        uri: 'file:///path/to/as.predefined',
+        content: `
+            class Box<T> {
+                T value;
+            }
+
+            class Item {
+                int weight;
+            }
+
+            class Box<Item> {
+                int specialWeight;
+            }
+
+            class Weapon {
+                int damage;
+            }
+            `
+    }, {
+        uri: 'file:///path/to/file.as',
+        content: `// Template specialization is used when available.
+            void main() {
+                Box<Item> special;
+                special.specialWeight = 42;
+
+                Box<Weapon> generic;
+                generic.value.damage = 10;
+            }
+            `
+    }]);
+
+    expectError([{
+        uri: 'file:///path/to/as.predefined',
+        content: `
+            class Cache<T> {
+                T data;
+            }
+
+            class Record {
+                int id;
+            }
+
+            class Cache<Record> {
+                int capacity;
+            }
+            `
+    }, {
+        uri: 'file:///path/to/file.as',
+        content: `// Specialization does not have generic member 'data'.
+            void main() {
+                Cache<Record> cache;
+                cache.data.id;
+            }
+            `
+    }]);
+});


### PR DESCRIPTION
Adds template specialization support and fixes generic field resolution.

Generic member resolution:
```angelscript
class Container<T> {
    T item;
}

class Player {
    int health;
}

Container<Player> container;
// container.item is Player
container.item.health = 100;
```

Template specialization:
```angelscript
class Box<T> {
    T value;
}

class Item {
    int weight;
}

class Box<Item> {
    int specialWeight;
}

Box<Item> box;
// box.specialWeight resolves via specialization
box.specialWeight = 42;
```
