### PR TITLE
Fix/funcdef definition

### DIFF
--- a/server/src/compiler_analyzer/analyzer.ts
+++ b/server/src/compiler_analyzer/analyzer.ts
@@ -1525,6 +1525,8 @@ function analyzeVariableAccess(
     }
 
     if (found.symbol.isVariable()) {
+        // NOTE: Delegate variables also go through here.
+
         const accessedVariable = found.symbol.toList()[0];
         if (accessedVariable.identifierToken.location.path !== '') {
             // Only add to the reference list if the identifier has a valid path.
@@ -1540,8 +1542,7 @@ function analyzeVariableAccess(
         // Unlike variables, function access is not added to the reference here.
         // It will be added once overload resolution is completed.
 
-        return ResolvedType.create({typeOrFunc: found.symbol.first, accessSource: varIdentifier});
-        // <-- Function (tentatively using the first overload)
+        return ResolvedType.create({typeOrFunc: found.symbol.first, accessSource: varIdentifier}); // <-- Function (tentatively using the first overload)
     }
 }
 

--- a/server/src/compiler_analyzer/analyzer.ts
+++ b/server/src/compiler_analyzer/analyzer.ts
@@ -1537,12 +1537,12 @@ function analyzeVariableAccess(
             });
         }
 
-        return found.symbol.type?.cloneWithAccessSource(accessedVariable); // <-- Variable
+        return found.symbol.type?.cloneWithAttachedAccessSource(accessedVariable); // <-- Variable
     } else {
         // Unlike variables, function access is not added to the reference here.
         // It will be added once overload resolution is completed.
 
-        return ResolvedType.create({typeOrFunc: found.symbol.first, accessSource: varIdentifier}); // <-- Function (tentatively using the first overload)
+        return ResolvedType.create({typeOrFunc: found.symbol.first, attachedAccessSource: varIdentifier}); // <-- Function (tentatively using the first overload)
     }
 }
 

--- a/server/src/compiler_analyzer/operatorCall.ts
+++ b/server/src/compiler_analyzer/operatorCall.ts
@@ -168,7 +168,7 @@ function handleMismatchError(args: OverloadedOperatorCallArgs, lhsReason: Mismat
         const rhsText = Array.isArray(rhs) ? stringifyResolvedTypes(rhs) : stringifyResolvedType(rhs);
         analyzerDiagnostic.error(
             args.rhsRange.getBoundingLocation(),
-            `'${lhs.accessSourceToken?.text ?? '[ ]'}' expects one integer argument, but got '${rhsText}'.`
+            `'${lhs.attachedAccessSourceToken?.text ?? '[ ]'}' expects one integer argument, but got '${rhsText}'.`
         );
         return;
     }
@@ -216,10 +216,10 @@ function checkLhsOverloadedOperatorCall(args: LhsOperatorCallArgs): ResolvedType
 
     const rhsArgs = Array.isArray(args.rhs) ? args.rhs : [args.rhs];
 
-    if (lhs.accessSourceVariable?.isIndexedPropertyAccessor) {
+    if (lhs.attachedAccessSourceVariable?.isIndexedPropertyAccessor) {
         if (rhsArgs.length == 1 && canTypeConvert(rhsArgs[0], resolvedBuiltinInt)) {
             // e.g., `myNotebook[123]` where `class MyNotebook { string get_texts(int idx) property { ... } }`
-            return lhs.accessSourceVariable.type;
+            return lhs.attachedAccessSourceVariable.type;
         }
 
         return {reason: MismatchKind.MismatchIndexedPropertyAccessor};

--- a/server/src/compiler_analyzer/resolvedType.ts
+++ b/server/src/compiler_analyzer/resolvedType.ts
@@ -91,7 +91,7 @@ export class ResolvedType {
         typeOrFunc: TypeSymbol | FunctionSymbol;
         isHandle?: boolean;
         templateTranslator?: TemplateTranslator;
-        accessSource?: VariableSymbol | TokenObject;
+        attachedAccessSource?: VariableSymbol | TokenObject;
         isExplicitHandleReference?: boolean;
         lambdaInfo?: LambdaInfo;
     }) {
@@ -99,7 +99,7 @@ export class ResolvedType {
             args.typeOrFunc,
             args.isHandle,
             args.templateTranslator,
-            args.accessSource,
+            args.attachedAccessSource,
             args.isExplicitHandleReference,
             args.lambdaInfo
         );
@@ -138,12 +138,12 @@ export class ResolvedType {
         );
     }
 
-    public cloneWithAccessSource(accessSource: VariableSymbol | TokenObject | undefined): ResolvedType {
+    public cloneWithAttachedAccessSource(attachedAccessSource: VariableSymbol | TokenObject | undefined): ResolvedType {
         return new ResolvedType(
             this.typeOrFunc,
             this.isHandle,
             this.templateTranslator,
-            accessSource,
+            attachedAccessSource,
             this.isExplicitHandleAccess,
             this.lambdaInfo
         );
@@ -161,7 +161,7 @@ export class ResolvedType {
         return this.typeOrFunc.identifierToken.text;
     }
 
-    public get accessSourceVariable(): VariableSymbol | undefined {
+    public get attachedAccessSourceVariable(): VariableSymbol | undefined {
         return this._attachedAccessSource instanceof VariableSymbol ? this._attachedAccessSource : undefined;
     }
 
@@ -169,7 +169,7 @@ export class ResolvedType {
         return this._attachedAccessSource instanceof VariableSymbol === false ? this._attachedAccessSource : undefined;
     }
 
-    public get accessSourceToken(): TokenObject | undefined {
+    public get attachedAccessSourceToken(): TokenObject | undefined {
         if (this._attachedAccessSource === undefined) {
             return undefined;
         }

--- a/server/src/compiler_analyzer/resolvedType.ts
+++ b/server/src/compiler_analyzer/resolvedType.ts
@@ -80,7 +80,9 @@ export class ResolvedType {
         public readonly typeOrFunc: TypeSymbol | FunctionSymbol,
         public readonly isHandle?: boolean,
         public readonly templateTranslator?: TemplateTranslator,
-        public readonly accessSource?: VariableSymbol | TokenObject, // This is attached when accessing from the variable.
+        // This is attached when accessed through a variable, including a delegate variable.
+        // For functions, only the token information of the access source is retained.
+        private _attachedAccessSource?: VariableSymbol | TokenObject,
         public readonly isExplicitHandleAccess?: boolean,
         public readonly lambdaInfo?: LambdaInfo
     ) {}
@@ -108,7 +110,7 @@ export class ResolvedType {
             this.typeOrFunc,
             this.isHandle,
             templateTranslator,
-            this.accessSource,
+            this._attachedAccessSource,
             this.isExplicitHandleAccess,
             this.lambdaInfo
         );
@@ -119,7 +121,7 @@ export class ResolvedType {
             this.typeOrFunc,
             isHandle,
             this.templateTranslator,
-            this.accessSource,
+            this._attachedAccessSource,
             this.isExplicitHandleAccess,
             this.lambdaInfo
         );
@@ -130,7 +132,7 @@ export class ResolvedType {
             this.typeOrFunc,
             this.isHandle,
             this.templateTranslator,
-            this.accessSource,
+            this._attachedAccessSource,
             isExplicitHandleReference,
             this.lambdaInfo
         );
@@ -160,19 +162,23 @@ export class ResolvedType {
     }
 
     public get accessSourceVariable(): VariableSymbol | undefined {
-        return this.accessSource instanceof VariableSymbol ? this.accessSource : undefined;
+        return this._attachedAccessSource instanceof VariableSymbol ? this._attachedAccessSource : undefined;
+    }
+
+    public get attachedAccessSourceFunctionToken(): TokenObject | undefined {
+        return this._attachedAccessSource instanceof VariableSymbol === false ? this._attachedAccessSource : undefined;
     }
 
     public get accessSourceToken(): TokenObject | undefined {
-        if (this.accessSource === undefined) {
+        if (this._attachedAccessSource === undefined) {
             return undefined;
         }
 
-        if (this.accessSource instanceof VariableSymbol) {
-            return this.accessSource.identifierToken;
+        if (this._attachedAccessSource instanceof VariableSymbol) {
+            return this._attachedAccessSource.identifierToken;
         }
 
-        return this.accessSource;
+        return this._attachedAccessSource;
     }
 
     public equals(other: ResolvedType | undefined): boolean {

--- a/server/src/compiler_analyzer/typeConversionSideEffect.ts
+++ b/server/src/compiler_analyzer/typeConversionSideEffect.ts
@@ -2,6 +2,7 @@ import {ResolvedType} from './resolvedType';
 import {getActiveGlobalScope, resolveActiveScope} from './symbolScope';
 import {TokenRange} from '../compiler_tokenizer/tokenRange';
 import {ConversionEvaluation} from './typeConversion';
+import {VariableSymbol} from './symbolObject';
 
 export function causeTypeConversionSideEffect(
     evaluation: ConversionEvaluation,
@@ -18,15 +19,15 @@ export function causeTypeConversionSideEffect(
         src.lambdaInfo?.resolve(evaluation.lambdaTarget, nodeRange);
     }
 
-    if (evaluation.resolvedOverload !== undefined && src.accessSourceToken !== undefined) {
+    if (evaluation.resolvedOverload !== undefined && src.attachedAccessSourceFunctionToken !== undefined) {
         // e.g., adding a reference for `my_function` in `@my_funcdef(my_function)
         getActiveGlobalScope().pushReference({
             toSymbol: evaluation.resolvedOverload,
-            fromToken: src.accessSourceToken
+            fromToken: src.attachedAccessSourceFunctionToken
         });
     }
 
-    // Resolve the type of an ambiguous enum member.
+    // Resolve the type of ambiguous enum member.
     if (src.typeOrFunc.isType() && src.typeOrFunc.multipleEnumCandidates !== undefined) {
         const enumScope = resolveActiveScope(dest.scopePath ?? []).lookupScope(dest.identifierText);
         const enumMember = enumScope?.lookupSymbol(src.typeOrFunc.identifierText);

--- a/server/test/services/definition/funcdef.spec.ts
+++ b/server/test/services/definition/funcdef.spec.ts
@@ -62,4 +62,32 @@ describe('definition/funcdef', () => {
             }
         `);
     });
+
+    it('resolves an auto funcdef handle variable at its declaration', () => {
+        testDefinition(`
+            funcdef void callback_f();
+            
+            void ignore(callback_f@ f) { }
+            
+            void do_nothing() { }
+            
+            auto my_f$C0$$C1$ = callback_f(@do_nothing);
+        `);
+    });
+
+    it('resolves an auto funcdef handle variable after it is used as an argument', () => {
+        testDefinition(`
+            funcdef void callback_f();
+            
+            void ignore(callback_f@ f) { }
+            
+            void do_nothing() { }
+            
+            auto my_f$C0$$C1$ = callback_f(@do_nothing);
+            
+            void f() {
+               ignore(my_f$C2$);
+            }
+        `);
+    });
 });


### PR DESCRIPTION
Fixed a bug that occurred when jumping to the definition in the following code:

```c++
funcdef void callback_f();

void ignore(callback_f@ f) { }

void do_nothing() { }

auto my_f = callback_f(@do_nothing);

void f() {
   ignore(my_f);
}
```