### PR TITLE
fix: better support scientific number

### DIFF
--- a/server/src/compiler_tokenizer/tokenizer.ts
+++ b/server/src/compiler_tokenizer/tokenizer.ts
@@ -157,41 +157,34 @@ function consumeNumber(tokenizer: TokenizerState) {
     }
 
     // Read until it is 0-9.
-    let integerDigits = 0;
     while (tokenizer.isEnd() === false && isDigit(tokenizer)) {
         tokenizer.stepNext();
-        integerDigits++;
     }
 
     let numberLiteral = NumberLiteral.Integer;
-    let hasSignificandDigit = integerDigits > 0;
 
     // Check if it is a floating point number
     let f = 0;
     if (tokenizer.next() === '.') {
-        let fractionOffset = 1;
-        let fractionDigits = 0;
-        while (isDigit(tokenizer, fractionOffset)) {
-            fractionOffset++;
-            fractionDigits++;
+        f++;
+        while (isDigit(tokenizer, f)) {
+            f++;
         }
 
-        if (fractionDigits > 0 || integerDigits > 0) {
-            f = fractionOffset;
-            numberLiteral = NumberLiteral.Double;
-            hasSignificandDigit = true;
-        }
+        numberLiteral = NumberLiteral.Double;
     }
 
     // Check if it has an exponent
-    // e.g. 1e3, 1e+3, 1E-3
-    if (hasSignificandDigit && /^[eE]$/.test(tokenizer.next(f))) {
-        const hasSign = /^[+-]$/.test(tokenizer.next(f + 1));
-        const exponentOffset = hasSign ? f + 2 : f + 1;
+    // e.g., 1e+3, 1E-3
+    if (/^[eE]$/.test(tokenizer.next(f))) {
+        const case1 = isDigit(tokenizer, f + 1); // e.g., 1e2
+        const case2 = !case1 && /^[+-]$/.test(tokenizer.next(f + 1)) && isDigit(tokenizer, f + 2); // e.g., 1e+3
+        if (case1 || case2) {
+            f += case1 ? 2 : 3;
+            while (isDigit(tokenizer, f)) {
+                f++;
+            }
 
-        if (isDigit(tokenizer, exponentOffset)) {
-            f = exponentOffset + 1;
-            while (isDigit(tokenizer, f)) f++;
             numberLiteral = NumberLiteral.Double;
         }
     }

--- a/server/src/compiler_tokenizer/tokenizer.ts
+++ b/server/src/compiler_tokenizer/tokenizer.ts
@@ -157,32 +157,43 @@ function consumeNumber(tokenizer: TokenizerState) {
     }
 
     // Read until it is 0-9.
+    let integerDigits = 0;
     while (tokenizer.isEnd() === false && isDigit(tokenizer)) {
         tokenizer.stepNext();
+        integerDigits++;
     }
 
     let numberLiteral = NumberLiteral.Integer;
+    let hasSignificandDigit = integerDigits > 0;
 
     // Check if it is a floating point number
     let f = 0;
     if (tokenizer.next() === '.') {
-        f++;
-        while (isDigit(tokenizer, f)) {
-            f++;
+        let fractionOffset = 1;
+        let fractionDigits = 0;
+        while (isDigit(tokenizer, fractionOffset)) {
+            fractionOffset++;
+            fractionDigits++;
         }
 
-        numberLiteral = NumberLiteral.Double;
+        if (fractionDigits > 0 || integerDigits > 0) {
+            f = fractionOffset;
+            numberLiteral = NumberLiteral.Double;
+            hasSignificandDigit = true;
+        }
     }
 
     // Check if it has an exponent
-    // e.g. 1e+3, 1E-3
-    if (/^[eE]$/.test(tokenizer.next(f)) && /^[+-]$/.test(tokenizer.next(f + 1)) && isDigit(tokenizer, f + 2)) {
-        f += 3;
-        while (isDigit(tokenizer, f)) {
-            f++;
-        }
+    // e.g. 1e3, 1e+3, 1E-3
+    if (hasSignificandDigit && /^[eE]$/.test(tokenizer.next(f))) {
+        const hasSign = /^[+-]$/.test(tokenizer.next(f + 1));
+        const exponentOffset = hasSign ? f + 2 : f + 1;
 
-        numberLiteral = NumberLiteral.Double;
+        if (isDigit(tokenizer, exponentOffset)) {
+            f = exponentOffset + 1;
+            while (isDigit(tokenizer, f)) f++;
+            numberLiteral = NumberLiteral.Double;
+        }
     }
 
     if (f >= 1) {

--- a/server/test/compiler/parser.spec.ts
+++ b/server/test/compiler/parser.spec.ts
@@ -138,4 +138,21 @@ describe('Parser', () => {
     it('rejects an incomplete function declaration', () => {
         expectFailure('void foo(');
     });
+
+    it('parses exponential notation', () => {
+        expectSuccess(`
+            double e0 = 1e10;
+            e0 = 1e+10;
+            e0 = 1e-10;
+            e0 = 1.5e10;
+            e0 = 1.5e+10;
+            e0 = 1.5e-10;
+            e0 = .5e10;
+            e0 = .5e+10;
+            e0 = .5e-10;
+            e0 = 1.E10;
+            e0 = 1.E+10;
+            e0 = 1.E-10;
+        `);
+    });
 });


### PR DESCRIPTION
Current checking for scientific number is not well. It will report error with following code:

```angelscript
int a  = 1e2;
```

It's valid code for AngelScript. However, angel-lsp will give a false positive on it. This PR will fix the problem.