### PR TITLE
Keep whitespace after not keyword

### DIFF
--- a/server/src/formatter/formatter.ts
+++ b/server/src/formatter/formatter.ts
@@ -979,7 +979,8 @@ function formatExprTerm(format: FormatterState, exprTerm: Node_ExprTerm) {
         formatInitList(format, exprTerm.initList);
     } else if (exprTerm.exprTerm === 2) {
         for (let i = 0; i < exprTerm.preOps.length; i++) {
-            formatTargetBy(format, exprTerm.preOps[i].text, {condenseRight: true});
+            const condenseRight = exprTerm.preOps[i].text !== 'not';
+            formatTargetBy(format, exprTerm.preOps[i].text, {condenseRight});
         }
 
         formatExprValue(format, exprTerm.value);

--- a/server/test/formatter.spec.ts
+++ b/server/test/formatter.spec.ts
@@ -80,4 +80,18 @@ void main() {
 }
 `
     );
+    testFormatter(
+        /* before */ `
+void foo(){
+if( not  value or not( ~ bar>1 and ++ bar<10) ){
+return;}}
+`,
+        /* after */ `
+void foo() {
+    if (not value or not (~bar > 1 and ++bar < 10)) {
+        return;
+    }
+}
+`
+    );
 });


### PR DESCRIPTION
Previously, all whitespace after the not keyword was being removed, meaning that `not value` would be formatted into `notvalue`, breaking the program.